### PR TITLE
RFC: Change constructor behavior

### DIFF
--- a/src/UniqueVectors.jl
+++ b/src/UniqueVectors.jl
@@ -13,8 +13,9 @@ struct UniqueVector{T} <: AbstractUniqueVector{T}
     lookup::Dict{T,Int}
 
     UniqueVector{T}() where {T} = new(T[], Dict{T,Int}())
-    function UniqueVector{T}(items::Vector{T}) where {T}
-        uv = new(items, Dict{T,Int}())
+
+    function UniqueVector{T}(items) where {T}
+        uv = new(Vector{T}(items), Dict{T,Int}())
         sizehint!(uv.lookup, length(uv.items))
         for (i, item) in enumerate(uv.items)
             if item in uv
@@ -27,11 +28,11 @@ struct UniqueVector{T} <: AbstractUniqueVector{T}
     end
 end
 
-UniqueVector(items::Vector{T}) where {T} = UniqueVector{T}(items)
-UniqueVector(items::AbstractVector{T}) where {T} = UniqueVector{T}(Vector{T}(items))
-UniqueVector(items) = UniqueVector(collect(items))
+UniqueVector(items::AbstractVector{T}) where {T} = UniqueVector{T}(items)
 
-copy(uv::UniqueVector) = UniqueVector(copy(uv.items))
+@deprecate UniqueVector(items) UniqueVector(collect(items))
+
+copy(uv::UniqueVector) = UniqueVector(uv.items)
 
 @delegate UniqueVector.items [ length, size, isempty, getindex, iterate ]
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -47,7 +47,7 @@ uv2 = UniqueVector([1, 2, 3])
 @test eltype(uv2) == Int
 @test findfirst(isequal(0x02), uv2) == 2
 @test findfirst!(isequal(0x02), uv2) == 2
-@test uv2 == UniqueVector(i for i in 1:3)
+@test uv2 == UniqueVector(collect(i for i in 1:3))
 for elt in [3,2,1]
     @test pop!(uv2) == elt
 end
@@ -148,3 +148,9 @@ uv5[1] = 4
 @test findprev(isequal(7), UniqueVector([3,5,7,9]), 2) == nothing
 @test findprev(isequal(7), UniqueVector([3,5,7,9]), 3) == 3
 @test findprev(isequal(7), UniqueVector([3,5,7,9]), 4) == 3
+
+# Test constructor behavior (#7)
+let items = [1,2,3]
+    @test UniqueVector(items).items !== items
+    @test UniqueVector{Int}(items).items !== items
+end


### PR DESCRIPTION
With this, `UniqueVector(vec::Vector)` makes a copy of `vec` before referencing it from the `UniqueVector` data structure.

This will match the behavior of `Vector(vec)`, which also copies `vec`.