### PR TITLE
View + getindex

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "UniqueVectors"
 uuid = "2fbcfb34-fd0c-5fbb-b5d7-e826d8f5b0a9"
-version = "0.8.1"
+version = "0.9"
 
 [deps]
 InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,9 @@
 name = "UniqueVectors"
 uuid = "2fbcfb34-fd0c-5fbb-b5d7-e826d8f5b0a9"
-version = "0.8.0"
+version = "0.8.1"
+
+[deps]
+InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
 [compat]
 julia = "1"

--- a/src/UniqueVectors.jl
+++ b/src/UniqueVectors.jl
@@ -2,7 +2,7 @@ module UniqueVectors
 
 include("delegate.jl")
 
-import Base: copy, in, getindex, findfirst, findlast, length, size, isempty, iterate, empty!, push!, pop!, setindex!, indexin, findnext, findprev, findall, count, allunique, unique, unique!
+import Base: copy, in, getindex, findfirst, findlast, length, size, isempty, iterate, empty!, push!, pop!, setindex!, getindex, indexin, findnext, findprev, findall, count, allunique, unique, unique!
 
 EqualTo = Base.Fix2{typeof(isequal)}
 
@@ -60,6 +60,11 @@ end
 
 findfirst(p::EqualTo, uv::UniqueVector{T}) where {T} =
     findfirst(isequal(convert(T, p.x)), uv)
+
+function findfirst(p::EqualTo, uv::SubArray{<:Any,1,<:AbstractUniqueVector})
+    ip = findfirst(p, uv.parent)
+    ip === nothing ? nothing : findfirst(isequal(ip), first(uv.indices))
+end
 
 findfirst!(p::EqualTo, uv::UniqueVector{T}) where {T} =
     findfirst!(isequal(convert(T, p.x)), uv)
@@ -139,6 +144,10 @@ end
 
 setindex!(uv::UniqueVector{T}, item, idx::Integer) where {T} =
     setindex!(uv, convert(T, item), idx)
+
+getindex(uv::UniqueVector, idx::AbstractVector) =
+    UniqueVector(uv.items[idx])
+
 
 "`swap!(uv::UniqueVector, to::Int, from::Int)` interchange/swap the values on the indices `to` and `from` in the `UniqueVector`"
 function swap!(uv::UniqueVector, to::Int, from::Int)

--- a/src/UniqueVectors.jl
+++ b/src/UniqueVectors.jl
@@ -145,10 +145,6 @@ end
 setindex!(uv::UniqueVector{T}, item, idx::Integer) where {T} =
     setindex!(uv, convert(T, item), idx)
 
-getindex(uv::UniqueVector, idx::AbstractVector) =
-    UniqueVector(uv.items[idx])
-
-
 "`swap!(uv::UniqueVector, to::Int, from::Int)` interchange/swap the values on the indices `to` and `from` in the `UniqueVector`"
 function swap!(uv::UniqueVector, to::Int, from::Int)
     if to == from

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -114,7 +114,6 @@ uv4[1] = "cat"
 push!(uv4, "mouse")
 @test uv4[:] == ["cat", "horse", "dog", "mouse"]
 @test uv4[1:2] == ["cat", "horse"]
-@test uv4[1:2] isa UniqueVector
 
 # Test view
 @test view(uv4, 2:3) isa SubArray

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using UniqueVectors
 using Test
+using InteractiveUtils: @which
 
 @test length(UniqueVector([1,5,6,3])) == 4
 @test_throws ArgumentError UniqueVector([1,3,5,6,3])
@@ -113,6 +114,12 @@ uv4[1] = "cat"
 push!(uv4, "mouse")
 @test uv4[:] == ["cat", "horse", "dog", "mouse"]
 @test uv4[1:2] == ["cat", "horse"]
+@test uv4[1:2] isa UniqueVector
+
+# Test view
+@test view(uv4, 2:3) isa SubArray
+@test findfirst(isequal("dog"), view(uv4, 2:3)) == 2
+@test @which(findfirst(isequal("dog"), view(uv4, 2:3))).module == UniqueVectors
 
 uv5 = UniqueVector{Float64}()
 push!(uv5, 3)


### PR DESCRIPTION
Just found this package, looks neat. 

I was wondering whether `uv[1:10]` should be another `UniqueVector`, whether `view(uv, 1:10)` could behave as if it were one. So I tried this out:

```
julia> using UniqueVectors, BenchmarkTools

julia> uv = UniqueVector(rand(Int, 10^4));

julia> n = uv[5000];

julia> @btime findfirst(isequal($n), $uv)
  5.599 ns (0 allocations: 0 bytes)
5000

julia> @btime findfirst(isequal($n), $(uv[2:2:end])) # was 1.401 μs
  5.595 ns (0 allocations: 0 bytes)
2500

julia> @btime findfirst(isequal($n), $(@view uv[2:2:end])) # was 1.880 μs
  13.634 ns (0 allocations: 0 bytes)
2500
```

The downside of the getindex overload is that of course you pay the cost of creating a new one:
```
julia> @btime $uv[2:2:end]; # was 3.696 μs
  108.712 μs (10 allocations: 176.02 KiB)
```
