### PR TITLE
Fast path for == not just isequal?

### DIFF
--- a/src/UniqueVectors.jl
+++ b/src/UniqueVectors.jl
@@ -48,8 +48,10 @@ in(item, uv::UniqueVector{T}) where {T} = in(convert(T, item), uv)
 findfirst(p::EqualTo{<:T}, uv::UniqueVector{T}) where {T} =
     get(uv.lookup, p.x, nothing)
 
-findfirst(p::Base.Fix2{typeof(==),<:T}, uv::UniqueVector{T}) where {T<:AbstractFloat} =
-    findfirst(p, uv.items)
+findfirst(p::Base.Fix2{typeof(==)}, uv::UniqueVector{<:AbstractFloat}) =
+    iszero(p.x) ? findfirst(p, uv.items) :
+    isnan(p.x) ? nothing :
+    get(uv.lookup, p.x, nothing)
 findfirst(p::Base.Fix2{typeof(==),Missing}, uv::UniqueVector) =
     throw(TypeError(:findfirst, "", Bool, missing))
 

--- a/src/UniqueVectors.jl
+++ b/src/UniqueVectors.jl
@@ -4,7 +4,7 @@ include("delegate.jl")
 
 import Base: copy, in, getindex, findfirst, findlast, length, size, isempty, iterate, empty!, push!, pop!, setindex!, indexin, findnext, findprev, findall, count, allunique, unique, unique!
 
-EqualTo = Base.Fix2{typeof(isequal)}
+EqualTo{T} = Union{Base.Fix2{typeof(isequal),T}, Base.Fix2{typeof(==),T}}
 
 abstract type AbstractUniqueVector{T} <: AbstractVector{T} end
 
@@ -47,6 +47,11 @@ in(item, uv::UniqueVector{T}) where {T} = in(convert(T, item), uv)
 
 findfirst(p::EqualTo{<:T}, uv::UniqueVector{T}) where {T} =
     get(uv.lookup, p.x, nothing)
+
+findfirst(p::Base.Fix2{typeof(==),<:T}, uv::UniqueVector{T}) where {T<:AbstractFloat} =
+    findfirst(p, uv.items)
+findfirst(p::Base.Fix2{typeof(==),Missing}, uv::UniqueVector) =
+    throw(TypeError(:findfirst, "", Bool, missing))
 
 function findfirst!(p::EqualTo{<:T}, uv::UniqueVector{T}) where {T}
     rv = get!(uv.lookup, p.x) do

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -142,3 +142,18 @@ uv5[1] = 4
 @test findprev(isequal(7), UniqueVector([3,5,7,9]), 2) == nothing
 @test findprev(isequal(7), UniqueVector([3,5,7,9]), 3) == 3
 @test findprev(isequal(7), UniqueVector([3,5,7,9]), 4) == 3
+
+# Test == vs isequal, differ on floats & missing
+@test findfirst(isequal("horse"), uv4) == findfirst(==("horse"), uv4)
+
+@test_throws Exception UniqueVector([1.0,2.0,NaN,4.0,NaN])
+uv6 = UniqueVector([1.0,2.0,-0.0,4,0.0,6.0,NaN])
+@test findfirst(isequal(0.0), uv6) == 5
+@test findfirst(==(0.0), uv6) == 3
+@test findfirst(isequal(NaN), uv6) == 7
+@test findfirst(==(NaN), uv6) === nothing
+
+@test_throws Exception UniqueVector([1,2,missing,4,missing])
+uv7 = UniqueVector([1,2,missing,4])
+@test findfirst(isequal(missing), uv7) == 3
+@test_throws Exception findfirst(==(missing), uv7)


### PR DESCRIPTION
I thought it would be nice if `findfirst(==(10), uv)` could also be fast. 

Then I read the help for `isequal` and fiddled a bit to make this treat floats and `missing` correctly, I believe. However what it can't do is deal with arbitrary types which happen to have other differences between `isequal` and `==`. So I'm not entirely sure this is a good idea. 

If it is a good idea, it may still need a little more polish as regards the precise signatures & promotions etc. Some chance I've introduced method ambiguities. 