### PR TITLE
Add `permute!`, `invpermute!`

### DIFF
--- a/src/UniqueVectors.jl
+++ b/src/UniqueVectors.jl
@@ -2,7 +2,7 @@ module UniqueVectors
 
 include("delegate.jl")
 
-import Base: copy, in, getindex, findfirst, findlast, length, size, isempty, iterate, empty!, push!, pop!, setindex!, getindex, indexin, findnext, findprev, findall, count, allunique, unique, unique!
+import Base: copy, in, getindex, findfirst, findlast, length, size, isempty, iterate, empty!, push!, pop!, setindex!, getindex, indexin, findnext, findprev, findall, count, allunique, unique, unique!, permute!, invpermute!
 
 EqualTo = Base.Fix2{typeof(isequal)}
 
@@ -163,6 +163,21 @@ function swap!(uv::UniqueVector, to::Int, from::Int)
     uv.lookup[previous_id] = from
     uv.lookup[future_id]   = to
 
+    return uv
+end
+
+function permute!(uv::UniqueVector, perm::AbstractVector)
+    map!(uv.lookup.vals, uv.lookup.vals) do i
+        k = findfirst(isequal(i), perm)
+        something(k, 0)
+    end
+    permute!(uv.items, perm)
+    return uv
+end
+
+function invpermute!(uv::UniqueVector, perm::AbstractVector)
+    map!(i -> get(perm, i, 0), uv.lookup.vals, uv.lookup.vals)
+    invpermute!(uv.items, perm)
     return uv
 end
 

--- a/src/UniqueVectors.jl
+++ b/src/UniqueVectors.jl
@@ -76,12 +76,10 @@ findlast(p::EqualTo, uv::AbstractUniqueVector) =
 indexin(a::AbstractArray, b::AbstractUniqueVector) =
     [findlast(isequal(elt), b) for elt in a]
 
-function findall(p::Base.Fix2{typeof(in),<:AbstractUniqueVector}, a::AbstractArray)
+function findall(p::Base.Fix2{typeof(in),<:AbstractUniqueVector},
+                 a::Union{Tuple, AbstractArray})
     # The version in Base creates a Set that is unnecessary in our case.  So
     # the override it here.
-    [i for (i, ai) in (@static if VERSION >= v"1.1.0-DEV.832" pairs else enumerate end)(a) if p(ai)]
-end
-function findall(p::Base.Fix2{typeof(in),<:AbstractUniqueVector}, a::Tuple)
     [i for (i, ai) in (@static if VERSION >= v"1.1.0-DEV.832" pairs else enumerate end)(a) if p(ai)]
 end
 

--- a/src/UniqueVectors.jl
+++ b/src/UniqueVectors.jl
@@ -167,14 +167,9 @@ function swap!(uv::UniqueVector, to::Int, from::Int)
 end
 
 function permute!(uv::UniqueVector, perm::AbstractVector)
-    # This allocates, but usually permute!(a, p) = permute!!(a, copymutable(p)) would anyway
     ip = invperm(perm)
     map!(i -> get(ip, i, 0), uv.lookup.vals, uv.lookup.vals)
-    if ismutable(ip)
-        Base.invpermute!!(uv.items, ip)  # save the allocation, so long as ip isn't an SVector or something
-    else
-        permute!(uv.items, perm)
-    end
+    permute!(uv.items, perm)
     return uv
 end
 

--- a/src/UniqueVectors.jl
+++ b/src/UniqueVectors.jl
@@ -167,11 +167,14 @@ function swap!(uv::UniqueVector, to::Int, from::Int)
 end
 
 function permute!(uv::UniqueVector, perm::AbstractVector)
-    map!(uv.lookup.vals, uv.lookup.vals) do i
-        k = findfirst(isequal(i), perm)
-        something(k, 0)
+    # This allocates, but usually permute!(a, p) = permute!!(a, copymutable(p)) would anyway
+    ip = invperm(perm)
+    map!(i -> get(ip, i, 0), uv.lookup.vals, uv.lookup.vals)
+    if ismutable(ip)
+        Base.invpermute!!(uv.items, ip)  # save the allocation, so long as ip isn't an SVector or something
+    else
+        permute!(uv.items, perm)
     end
-    permute!(uv.items, perm)
     return uv
 end
 

--- a/src/UniqueVectors.jl
+++ b/src/UniqueVectors.jl
@@ -76,10 +76,12 @@ findlast(p::EqualTo, uv::AbstractUniqueVector) =
 indexin(a::AbstractArray, b::AbstractUniqueVector) =
     [findlast(isequal(elt), b) for elt in a]
 
-function findall(p::Base.Fix2{typeof(in),<:AbstractUniqueVector},
-                 a::Union{Tuple, AbstractArray})
+function findall(p::Base.Fix2{typeof(in),<:AbstractUniqueVector}, a::AbstractArray)
     # The version in Base creates a Set that is unnecessary in our case.  So
     # the override it here.
+    [i for (i, ai) in (@static if VERSION >= v"1.1.0-DEV.832" pairs else enumerate end)(a) if p(ai)]
+end
+function findall(p::Base.Fix2{typeof(in),<:AbstractUniqueVector}, a::Tuple)
     [i for (i, ai) in (@static if VERSION >= v"1.1.0-DEV.832" pairs else enumerate end)(a) if p(ai)]
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -74,6 +74,7 @@ uv2 = copy(uv)
 @test uv2[:] == ["cat", "dog", "mouse"]
 @test findfirst(isequal("cat"), uv2) == 1
 
+# Test swap!
 let uv = UniqueVector(["cat", "dog", "mouse", "human"]), original = copy(uv)
 
     uv = swap!(uv, 2, 2)
@@ -88,6 +89,21 @@ let uv = UniqueVector(["cat", "dog", "mouse", "human"]), original = copy(uv)
 
     @test findfirst(isequal("dog"), uv) == 3
     @test findfirst(isequal("dog"), original) == 2
+end
+
+# Test permute! & inverse
+let uv = UniqueVector(["cat", "dog", "mouse", "human"]), original = copy(uv)
+    perm = sortperm(rand(4))
+    permute!(uv, perm)
+    @test uv == original[perm]
+    @test uv[findfirst(isequal("dog"), uv)] == "dog"
+
+    invpermute!(uv, perm)
+    @test uv == original
+
+    invpermute!(uv, perm)
+    @test uv == original[invperm(perm)]
+    @test uv[findfirst(isequal("dog"), uv)] == "dog"
 end
 
 @test UniqueVector([1,2,3,4]) == UniqueVector(1:4)


### PR DESCRIPTION
Help says "No checking is done to verify that p is a permutation." thus I didn't build in any explicit checks. But in practice it always seems to fail if `p` isn't a permutation, e.g. `permute!(rand(4), [1,2,1,3])`. 