### PR TITLE
RFC: Implement specialized `Base._findin` instead of `findall`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        julia-version: ['1.4', '1', 'nightly']
+        julia-version: ['1.2', '1', 'nightly']
         julia-arch: [x64, x86]
         os: [ubuntu-latest, windows-latest, macOS-latest]
         exclude:

--- a/Project.toml
+++ b/Project.toml
@@ -2,8 +2,5 @@ name = "UniqueVectors"
 uuid = "2fbcfb34-fd0c-5fbb-b5d7-e826d8f5b0a9"
 version = "1.2.0"
 
-[deps]
-SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
-
 [compat]
-julia = "1.4"
+julia = "1.2"

--- a/src/UniqueVectors.jl
+++ b/src/UniqueVectors.jl
@@ -87,7 +87,7 @@ indexin(a::AbstractArray, b::AbstractUniqueVector) =
 # `findall(::p::Base.Fix2{typeof(in),<:AbstractUniqueVector},
 # ::Union{AbstractArray, Tuple}` without causing further method ambiguities.
 # The relevant `findall` method in Base calls `_findin`, but `_findin` creates
-# a Set that is conceptually unnecessary for a UniqueArray.  Previous versions
+# a Set that is conceptually unnecessary for a UniqueVector.  Previous versions
 # of this code overrode `findall` itself here, but it was impossible to do so
 # in a general way that did not cause method ambiguities with other specialized
 # `findall` implementations, such as for the various sparse array types.  These


### PR DESCRIPTION
From the comment added in this PR:

> The goal here is to speed up `findall(::p::Base.Fix2{typeof(in),<:AbstractUniqueVector}, ::Union{AbstractArray, Tuple}` without causing further method ambiguities. The relevant `findall` method in `Base` calls `_findin`, but `_findin` creates a `Set` that is conceptually unnecessary for a `UniqueVector`.  Previous versions of this code overrode `findall` itself here, but it was impossible to do so in a general way that did not cause method ambiguities with other specialized `findall` implementations, such as for the various sparse array types.  These types have proliferated over time as Julia is further developed, so the below method seemed to be the cleanest solution.

Motivated by https://github.com/garrison/UniqueVectors.jl/pull/19#issuecomment-1426931184.

See also:
- #19
- #18
- #22 is partially reverted here
